### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module.exports = yeoman.Base.extend({
   writing: function () {
     var done = this.async();
 
-    remote('yeoman', 'generator', function (cachePath) {
+    remote('yeoman', 'generator', function (err, cachePath) {
       this.fs.copy(
         path.join(cachePath, 'lib/index.js'),
         this.destinationPath('lib/index.js')


### PR DESCRIPTION
`cachePath` should be the second argument according to the test.
https://github.com/yeoman/yeoman-remote/blob/5b1152f4745414215fd700a867b9d7650fac3617/test/remote.js#L29
