### PR TITLE
Update Download version.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,9 @@ remote.cacheRoot = function cacheRoot() {
  */
 
 remote.fetch = function _fetch(url, destination, cb) {
-  download(url, destination).then(cb);
+  download(url, destination).then(() => {
+    cb();
+  });
 };
 
 /**
@@ -145,5 +147,9 @@ remote.extract = function _extract(archive, destination, opts, cb) {
 
   opts = assign({extract: true}, opts);
 
-  download(archive, destination, opts).then(cb).catch((err) => cb(err));
+  download(archive, destination, opts).then(() => {
+    cb();
+  }).catch((err) => {
+    cb(err);
+  });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ remote.extract = function _extract(archive, destination, opts, cb) {
 
   download(archive, destination, opts).then(() => {
     cb();
-  }).catch((err) => {
+  }).catch(err => {
     cb(err);
   });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var _s = require('underscore.string');
 var rimraf = require('rimraf');
-var Download = require('download');
+var download = require('download');
 var xdgBasedir = require('xdg-basedir');
 var assign = require('lodash/assign');
 
@@ -125,18 +125,7 @@ remote.cacheRoot = function cacheRoot() {
  */
 
 remote.fetch = function _fetch(url, destination, cb) {
-  var download = new Download()
-    .get(url)
-    .dest(destination);
-
-  download.run(function (err) {
-    if (err) {
-      cb(err);
-      return;
-    }
-
-    cb();
-  });
+  download(url, destination).then(cb);
 };
 
 /**
@@ -156,16 +145,5 @@ remote.extract = function _extract(archive, destination, opts, cb) {
 
   opts = assign({extract: true}, opts);
 
-  var download = new Download(opts)
-    .get(archive)
-    .dest(destination);
-
-  download.run(function (err) {
-    if (err) {
-      cb(err);
-      return;
-    }
-
-    cb();
-  });
+  download(archive, destination, opts).then(cb).catch((err) => cb(err));
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "gulp"
   },
   "dependencies": {
-    "download": "^4.4.3",
+    "download": "^7.0.0",
     "lodash": "^4.13.1",
     "rimraf": "^2.5.0",
     "underscore.string": "^3.2.2",


### PR DESCRIPTION
There is a vulnerability in one of the dependencies of the dependencies, the main issue is with package Tunnel Agent but it has been updated in Caw, then Download is using the most recent version; but yeoman-remote needs the Download update to get that in. Here, I'm updating the Download version and fixing the code to use the new Download API.